### PR TITLE
feat: ポートフォリオのビジュアルリデザイン

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,20 +2,50 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Default  */
-.light {
-  background-color: rgb(255 251 235 / 1);
+@layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    @apply font-sans antialiased;
+  }
+
+  .light {
+    --bg-primary: #f8fafc;
+    --bg-secondary: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --accent: #06b6d4;
+    --card-bg: rgba(255, 255, 255, 0.7);
+    --card-border: rgba(148, 163, 184, 0.2);
+    background-color: var(--bg-primary);
+  }
+
+  .light .logo {
+    fill: #0f172a;
+  }
+
+  .dark {
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --text-primary: #f1f5f9;
+    --text-secondary: #94a3b8;
+    --accent: #22d3ee;
+    --card-bg: rgba(30, 41, 59, 0.7);
+    --card-border: rgba(148, 163, 184, 0.1);
+    background-color: var(--bg-primary);
+  }
+
+  .dark .logo {
+    fill: #f1f5f9;
+  }
 }
 
-.light .logo {
-  fill: #000;
-}
-
-/* Dark mode */
-.dark {
-  background-color: rgb(17 24 39 / 1);
-}
-
-.dark .logo {
-  fill: #fff;
+@layer components {
+  .glass-card {
+    @apply backdrop-blur-md border rounded-2xl;
+    background: var(--card-bg);
+    border-color: var(--card-border);
+  }
 }

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     %sveltekit.head%
     <script>
       (function () {

--- a/src/lib/actions/scrollReveal.ts
+++ b/src/lib/actions/scrollReveal.ts
@@ -1,0 +1,29 @@
+export function scrollReveal(node: HTMLElement, options?: { threshold?: number; delay?: number }) {
+  const threshold = options?.threshold ?? 0.1;
+  const delay = options?.delay ?? 0;
+
+  node.style.opacity = '0';
+  node.style.transform = 'translateY(20px)';
+  node.style.transition = `opacity 0.6s ease-out ${delay}ms, transform 0.6s ease-out ${delay}ms`;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          node.style.opacity = '1';
+          node.style.transform = 'translateY(0)';
+          observer.unobserve(node);
+        }
+      });
+    },
+    { threshold }
+  );
+
+  observer.observe(node);
+
+  return {
+    destroy() {
+      observer.disconnect();
+    }
+  };
+}

--- a/src/lib/components/DropDownMenu.svelte
+++ b/src/lib/components/DropDownMenu.svelte
@@ -50,11 +50,11 @@
       {/if}
     </DropdownMenu.Trigger>
     <DropdownMenu.Content
-      class="absolute right-[-11px] top-[11px] w-36 origin-top-right rounded-md bg-white dark:bg-gray-700 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none px-1 py-1 z-50"
+      class="absolute right-[-11px] top-[11px] w-36 origin-top-right rounded-xl bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl shadow-lg border border-slate-200 dark:border-slate-700 focus:outline-none px-1 py-1 z-50"
     >
       {#each menuItems as item}
         <DropdownMenu.Item
-          class="group flex w-full items-center rounded-md px-2 py-2 text-sm dark:text-white text-gray-900 hover:bg-gray-100 dark:hover:bg-violet-500 dark:hover:text-white focus:outline-none cursor-pointer"
+          class="group flex w-full items-center rounded-lg px-2 py-2 text-sm dark:text-slate-200 text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700 focus:outline-none cursor-pointer transition-colors"
           onSelect={() => {
             theme = item.targetTheme;
           }}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -2,9 +2,11 @@
   import { title } from '$lib/config';
 </script>
 
-<footer class="p-4 text-center bg-amber-50 dark:bg-gray-900 dark:text-white">
-  <span>
-    © {new Date().getFullYear()}
+<footer
+  class="py-8 text-center bg-slate-50 dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800"
+>
+  <span class="text-sm text-slate-500 dark:text-slate-400">
+    &copy; {new Date().getFullYear()}
     {title}
   </span>
 </footer>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -4,9 +4,9 @@
 </script>
 
 <header
-  class="px-4 backdrop-blur bg-white/60 dark:bg-black/60 shadow-lg border-b fixed top-0 left-0 w-full z-10"
+  class="px-4 backdrop-blur-xl bg-white/70 dark:bg-slate-900/70 shadow-sm border-b border-slate-200/50 dark:border-slate-700/50 fixed top-0 left-0 w-full z-50"
 >
-  <div class="flex justify-between items-center mx-auto w-11/12 lg:w-7/12 h-14">
+  <div class="flex justify-between items-center max-w-4xl mx-auto px-2 h-16">
     <h1 class="inline-block lg:w-60">
       <Logo />
     </h1>

--- a/src/lib/components/sections/Career.svelte
+++ b/src/lib/components/sections/Career.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import SectionRoot from '$lib/components/sections/SectionRoot.svelte';
+  import { scrollReveal } from '$lib/actions/scrollReveal';
 </script>
 
 <SectionRoot heading="Career">
   <div class="mb-6">
-    <p>
+    <p class="text-slate-600 dark:text-slate-300">
       詳しい経歴を知りたい方は
       <a
-        class="text-blue-600 hover:underline"
+        class="text-cyan-600 dark:text-cyan-400 hover:underline underline-offset-4"
         href="https://www.notion.so/1c12a367e430809bb589e935cfb58285"
         target="_blank"
         rel="noopener noreferrer"
@@ -17,94 +18,89 @@
       をご確認ください。
     </p>
   </div>
-  <div class="flex content-between">
-    <h3
-      class="w-1/4 pb-2 pr-4 font-bold relative after:absolute after:top-0 after:-right-[11px] after:w-5 after:h-5 after:bg-blue-500 after:rounded-full"
-    >
-      2017年8月
-    </h3>
-    <div class="border-l-2 px-6 pb-6 w-[calc(100%_-_40px)]">
-      <p class="lg:mb-10 mb-6">
-        大学5年生の時に一般教養科目を取っていなかったことに気づき、単位を取る目的でHTML・CSS基礎という授業を履修。
-        <br />
-        夏季集中講座という形で履修したので、学習期間は1ヶ月ちょっとくらいの期間でしたが、この期間でHTML・CSSの基礎を学習しました。
-        <br />
-        今思えば、これが自分のウェブのキャリアの始まりでした。
-      </p>
-    </div>
-  </div>
 
-  <div class="flex content-between">
-    <h3
-      class="w-1/4 pb-2 pr-4 font-bold relative after:absolute after:top-0 after:-right-[11px] after:w-5 after:h-5 after:bg-blue-500 after:rounded-full"
-    >
-      2018年3月
-    </h3>
-    <div class="border-l-2 px-6 pb-6 w-[calc(100%_-_40px)]">
-      <p class="lg:mb-10 mb-6">
-        都内の私立大学を1年遅れ（留年）で卒業。
-        <br />
-        卒業後はウェブ制作会社で簡単なHTML・CSSコーディングをしていました。
-        <br />
-        コーディング以外だと、記事案の見出しを考えてライターさんに発注する業務も行っていました。
-      </p>
-    </div>
-  </div>
+  <div class="relative pl-8">
+    <div class="absolute left-[7px] top-2 bottom-0 w-0.5 bg-slate-200 dark:bg-slate-700" />
 
-  <div class="flex content-between">
-    <h3
-      class="w-1/4 pt-2 pr-4 font-bold relative after:absolute after:top-2 after:-right-[11px] after:w-5 after:h-5 after:bg-blue-500 after:rounded-full"
-    >
-      2020年4月 〜 2021年4月
-    </h3>
-    <div class="border-l-2 px-6 pt-2 pb-6 w-[calc(100%_-_40px)]">
-      <p class="lg:mb-10 mb-6">
-        ウェブエンジニアとしてのキャリアをスタートしました。
-        <br />
-        エンジニア1年目はWordPressを使った自社メディアの構築やLPの制作を主に行っていました。
-        <br />
-        サイト制作以外にも、Laravelを使った社内ツールの開発や、GatsbyJSを使ったサイトのフロントエンド・バックエンド（Serverless
-        Frameworkを使用したマイクロサービス）の改修も行いました。
-      </p>
+    <div class="relative pb-12" use:scrollReveal={{ delay: 0 }}>
+      <div
+        class="absolute -left-8 top-1 w-4 h-4 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400 ring-4 ring-slate-50 dark:ring-slate-900"
+      />
+      <span class="text-sm font-semibold text-cyan-600 dark:text-cyan-400">2017年8月</span>
+      <div class="mt-3 glass-card p-5">
+        <p class="text-slate-600 dark:text-slate-300">
+          大学5年生の時に一般教養科目を取っていなかったことに気づき、単位を取る目的でHTML・CSS基礎という授業を履修。
+          夏季集中講座という形で履修したので、学習期間は1ヶ月ちょっとくらいの期間でしたが、この期間でHTML・CSSの基礎を学習しました。
+          今思えば、これが自分のウェブのキャリアの始まりでした。
+        </p>
+      </div>
     </div>
-  </div>
 
-  <div class="flex content-between">
-    <h3
-      class="w-1/4 pt-2 pr-4 font-bold relative after:absolute after:top-2 after:-right-[11px] after:w-5 after:h-5 after:bg-blue-500 after:rounded-full"
-    >
-      2021年4月 〜 2023年9月
-    </h3>
-    <div class="border-l-2 px-6 pt-2 pb-6 w-[calc(100%_-_40px)]">
-      <p>
-        自社SaaSアプリを開発する企業に転職して、アプリケーションのフロントエンド開発を行っていました。
-        <br />
-        主にTypeScript、React、Vite、Next.jsを使用していました。
-        <br />
-        IaCを用いたインフラの構築経験や、バックエンドの人手が足りなかった時にGoを使ったAPI開発にも携わりました。
-      </p>
+    <div class="relative pb-12" use:scrollReveal={{ delay: 100 }}>
+      <div
+        class="absolute -left-8 top-1 w-4 h-4 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400 ring-4 ring-slate-50 dark:ring-slate-900"
+      />
+      <span class="text-sm font-semibold text-cyan-600 dark:text-cyan-400">2018年3月</span>
+      <div class="mt-3 glass-card p-5">
+        <p class="text-slate-600 dark:text-slate-300">
+          都内の私立大学を1年遅れ（留年）で卒業。
+          卒業後はウェブ制作会社で簡単なHTML・CSSコーディングをしていました。
+          コーディング以外だと、記事案の見出しを考えてライターさんに発注する業務も行っていました。
+        </p>
+      </div>
     </div>
-  </div>
 
-  <div class="flex content-between">
-    <h3
-      class="w-1/4 pt-2 pr-4 font-bold relative after:absolute after:top-2 after:-right-[11px] after:w-5 after:h-5 after:bg-blue-500 after:rounded-full"
-    >
-      2023年10月 〜
-    </h3>
-    <div class="border-l-2 px-6 pt-2 pb-6 w-[calc(100%_-_40px)]">
-      <p>
-        会社を辞めて、フリーランスエンジニアになりました。主に以下のような開発に携わった経験があります。
-      </p>
-      <br />
-      <ul class="list-disc ml-4">
-        <li>
-          TypeScript・React・Vite・GraphQLを使ったtoBe向けアプリケーションのフロントエンドの実装
-        </li>
-        <li>NestJSを使ったAPIや認証・認可周りの設計・実装</li>
-        <li>GitHub Actionsを使ったCI/CDの構築</li>
-        <li>AWS Cognitoを使った認証基盤の構築、DBのmigration基盤の構築</li>
-      </ul>
+    <div class="relative pb-12" use:scrollReveal={{ delay: 200 }}>
+      <div
+        class="absolute -left-8 top-1 w-4 h-4 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400 ring-4 ring-slate-50 dark:ring-slate-900"
+      />
+      <span class="text-sm font-semibold text-cyan-600 dark:text-cyan-400"
+        >2020年4月 〜 2021年4月</span
+      >
+      <div class="mt-3 glass-card p-5">
+        <p class="text-slate-600 dark:text-slate-300">
+          ウェブエンジニアとしてのキャリアをスタートしました。
+          エンジニア1年目はWordPressを使った自社メディアの構築やLPの制作を主に行っていました。
+          サイト制作以外にも、Laravelを使った社内ツールの開発や、GatsbyJSを使ったサイトのフロントエンド・バックエンド（Serverless
+          Frameworkを使用したマイクロサービス）の改修も行いました。
+        </p>
+      </div>
+    </div>
+
+    <div class="relative pb-12" use:scrollReveal={{ delay: 300 }}>
+      <div
+        class="absolute -left-8 top-1 w-4 h-4 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400 ring-4 ring-slate-50 dark:ring-slate-900"
+      />
+      <span class="text-sm font-semibold text-cyan-600 dark:text-cyan-400"
+        >2021年4月 〜 2023年9月</span
+      >
+      <div class="mt-3 glass-card p-5">
+        <p class="text-slate-600 dark:text-slate-300">
+          自社SaaSアプリを開発する企業に転職して、アプリケーションのフロントエンド開発を行っていました。
+          主にTypeScript、React、Vite、Next.jsを使用していました。
+          IaCを用いたインフラの構築経験や、バックエンドの人手が足りなかった時にGoを使ったAPI開発にも携わりました。
+        </p>
+      </div>
+    </div>
+
+    <div class="relative pb-4" use:scrollReveal={{ delay: 400 }}>
+      <div
+        class="absolute -left-8 top-1 w-4 h-4 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400 ring-4 ring-slate-50 dark:ring-slate-900"
+      />
+      <span class="text-sm font-semibold text-cyan-600 dark:text-cyan-400">2023年10月 〜</span>
+      <div class="mt-3 glass-card p-5">
+        <p class="text-slate-600 dark:text-slate-300">
+          会社を辞めて、フリーランスエンジニアになりました。主に以下のような開発に携わった経験があります。
+        </p>
+        <ul class="list-disc ml-4 mt-3 text-slate-600 dark:text-slate-300">
+          <li>
+            TypeScript・React・Vite・GraphQLを使ったtoBe向けアプリケーションのフロントエンドの実装
+          </li>
+          <li>NestJSを使ったAPIや認証・認可周りの設計・実装</li>
+          <li>GitHub Actionsを使ったCI/CDの構築</li>
+          <li>AWS Cognitoを使った認証基盤の構築、DBのmigration基盤の構築</li>
+        </ul>
+      </div>
     </div>
   </div>
 </SectionRoot>

--- a/src/lib/components/sections/Cat.svelte
+++ b/src/lib/components/sections/Cat.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
-  /* 
-  document is not defined ReferenceError: document is not definedを防ぐために
-  コンポーネントがレンダリングされたときにブラウザでのみ実行されるonMount関数を使用する
-  */
   import { onMount } from 'svelte';
   import animationData from '$lib/data/cat.json';
-  import SectionRoot from '$lib/components/sections/SectionRoot.svelte';
 
-  // ライブラリ自体に型定義が存在せず、型が不明なのでanyを使用する
   let LottiePlayer: any;
 
   onMount(async () => {
@@ -31,22 +25,53 @@
   ];
 </script>
 
-{#if LottiePlayer}
-  <SectionRoot>
-    <div class="m-auto w-72 h-72">
-      <LottiePlayer
-        src={animationData}
-        autoplay={true}
-        loop={true}
-        controls={false}
-        renderer="svg"
-        background="transparent"
-        width={0}
-        height={0}
-        {controlsLayout}
-      />
+<section class="relative min-h-screen flex flex-col items-center justify-center overflow-hidden">
+  <div
+    class="absolute inset-0 bg-gradient-to-br from-cyan-50 via-slate-50 to-violet-50 dark:from-slate-900 dark:via-slate-900 dark:to-cyan-950"
+  />
+
+  <div
+    class="absolute top-1/4 -left-32 w-96 h-96 bg-cyan-400/20 dark:bg-cyan-400/10 rounded-full blur-3xl animate-float"
+  />
+  <div
+    class="absolute bottom-1/4 -right-32 w-96 h-96 bg-violet-400/20 dark:bg-violet-400/10 rounded-full blur-3xl animate-float"
+    style="animation-delay: -3s;"
+  />
+
+  <div class="relative z-10 text-center">
+    {#if LottiePlayer}
+      <div class="m-auto w-72 h-72 lg:w-80 lg:h-80">
+        <LottiePlayer
+          src={animationData}
+          autoplay={true}
+          loop={true}
+          controls={false}
+          renderer="svg"
+          background="transparent"
+          width={0}
+          height={0}
+          {controlsLayout}
+        />
+      </div>
+    {:else}
+      <div class="w-72 h-72 lg:w-80 lg:h-80" />
+    {/if}
+
+    <h2
+      class="mt-4 text-4xl lg:text-6xl font-extrabold tracking-tight text-slate-900 dark:text-white"
+    >
+      Karukichi Soejima
+    </h2>
+    <p class="mt-3 text-lg lg:text-xl text-slate-500 dark:text-slate-400 font-medium">
+      Web Developer
+    </p>
+  </div>
+
+  <div class="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce">
+    <div
+      class="w-6 h-10 rounded-full border-2 border-slate-400 dark:border-slate-500 flex justify-center pt-2"
+    >
+      <div class="w-1.5 h-1.5 rounded-full bg-slate-400 dark:bg-slate-500" />
     </div>
-  </SectionRoot>
-{:else}
-  <div class="w-72 h-72 lg:my-6 my-4" />
-{/if}
+  </div>
+</section>

--- a/src/lib/components/sections/Contact.svelte
+++ b/src/lib/components/sections/Contact.svelte
@@ -3,15 +3,17 @@
 </script>
 
 <SectionRoot heading="Contact">
-  <p>
-    <a
-      class="text-blue-600 hover:underline"
-      href="https://twitter.com/karukichi_yah"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      XのDM
-    </a>
-    までお願いします。
-  </p>
+  <div class="glass-card p-8 text-center">
+    <p class="text-lg text-slate-600 dark:text-slate-300">
+      <a
+        class="text-cyan-600 dark:text-cyan-400 hover:underline underline-offset-4 font-semibold"
+        href="https://twitter.com/karukichi_yah"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        XのDM
+      </a>
+      までお願いします。
+    </p>
+  </div>
 </SectionRoot>

--- a/src/lib/components/sections/Others.svelte
+++ b/src/lib/components/sections/Others.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import SectionRoot from '$lib/components/sections/SectionRoot.svelte';
+  import { scrollReveal } from '$lib/actions/scrollReveal';
   import { X, Github, Presentation, Pen, FileText } from 'lucide-svelte';
 
   const INFOS = [
@@ -32,21 +33,22 @@
 </script>
 
 <SectionRoot heading="Others">
-  <ul>
-    {#each INFOS as info}
-      <li class="items-center text-blue-600 last-of-type:pb-0">
-        <a
-          class="inline-block p-2 cursor-pointer font-bold hover:bg-blue-50 hover:rounded-lg"
-          href={info.url}
-          target="_blank"
-          rel="noopener noreferrer"
+  <div class="grid grid-cols-2 lg:grid-cols-3 gap-4">
+    {#each INFOS as info, i}
+      <a
+        class="glass-card p-5 flex flex-col items-center gap-3 text-center group hover:border-cyan-400 dark:hover:border-cyan-400 transition-all duration-300"
+        href={info.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        use:scrollReveal={{ delay: i * 80 }}
+      >
+        <span
+          class="text-slate-500 dark:text-slate-400 group-hover:text-cyan-500 transition-colors"
         >
-          <span class="inline-block align-middle pr-1">
-            <svelte:component this={info.componentName} size={16} />
-          </span>
-          <span>{info.name}</span>
-        </a>
-      </li>
+          <svelte:component this={info.componentName} size={24} />
+        </span>
+        <span class="text-sm font-medium text-slate-700 dark:text-slate-300">{info.name}</span>
+      </a>
     {/each}
-  </ul>
+  </div>
 </SectionRoot>

--- a/src/lib/components/sections/Profile.svelte
+++ b/src/lib/components/sections/Profile.svelte
@@ -1,52 +1,60 @@
 <script lang="ts">
   import SectionRoot from '$lib/components/sections/SectionRoot.svelte';
+  import { scrollReveal } from '$lib/actions/scrollReveal';
 </script>
 
 <SectionRoot heading="Profile">
   <div class="lg:mb-10 mb-6">
-    <div class="mb-2">
-      <span class="text-sm">カルキチ 副島</span>
-      <h3 class="text-xl font-bold">Karukichi Soejima</h3>
-    </div>
-    <div class="lg:flex lg:justify-between">
+    <div class="lg:flex lg:justify-between lg:items-center">
       <div>
-        <p>東京都で活動するウェブ開発者です。</p>
-        <p>アイコンのキャラクターの名前が「カルキチ」と言います。</p>
+        <span class="text-sm text-slate-500 dark:text-slate-400">カルキチ 副島</span>
+        <h3 class="text-xl font-bold text-slate-900 dark:text-white mb-3">Karukichi Soejima</h3>
+        <p class="text-slate-600 dark:text-slate-300">東京都で活動するウェブ開発者です。</p>
+        <p class="text-slate-600 dark:text-slate-300">
+          アイコンのキャラクターの名前が「カルキチ」と言います。
+        </p>
       </div>
       <div class="lg:text-start lg:m-0 text-center my-4">
         <img
           src="/icon.png"
           alt="Karukichi"
           width={100}
-          class="bg-white rounded-full border-gray-500 border m-auto"
+          class="bg-white rounded-full ring-4 ring-cyan-400/30 dark:ring-cyan-400/20 m-auto"
         />
-        <h4 class="text-sm mt-2">He is Karukichi.</h4>
+        <h4 class="text-sm mt-2 text-slate-500 dark:text-slate-400">He is Karukichi.</h4>
       </div>
     </div>
   </div>
-  <div class="lg:mb-10 mb-6">
-    <h3 class="text-xl font-bold mb-2">自身の強み</h3>
-    <p>ウェブのフロントエンド領域が比較的得意です。</p>
-    <p>チームの状況に応じて、バックエンドやクラウド(主にAWS)周りの課題を解決することもできます。</p>
-    <p>
-      ウェブアプリケーションだけではなく、ウェブ制作の経験もあるので、ウェブ領域全般でバリューを発揮することができます。
-    </p>
-  </div>
-  <div class="lg:mb-10 mb-6">
-    <h3 class="text-xl font-bold mb-2">関心のある技術</h3>
-    <ul class="list-disc ml-4">
-      <li>Web Frontend (React)</li>
-      <li>Backend (Node.js, Go)</li>
-      <li>AWS・Google Cloud等のパブリッククラウド</li>
-      <li>IaC (Infrastructure as Code)</li>
-      <li>Cloudflare</li>
-      <li>Vim (Neovim)</li>
-    </ul>
-  </div>
-  <div>
-    <h3 class="text-xl font-bold mb-2">趣味</h3>
-    <p>ファッションが好きです。</p>
-    <p>渋谷や表参道に服を買いに行くことが多いです。</p>
-    <p>あとは、カフェに行ったりするのも好きです。</p>
+
+  <div class="grid gap-6 lg:grid-cols-2">
+    <div class="glass-card p-6" use:scrollReveal={{ delay: 0 }}>
+      <h3 class="text-xl font-bold mb-3 text-slate-900 dark:text-white">自身の強み</h3>
+      <p class="text-slate-600 dark:text-slate-300">ウェブのフロントエンド領域が比較的得意です。</p>
+      <p class="text-slate-600 dark:text-slate-300">
+        チームの状況に応じて、バックエンドやクラウド(主にAWS)周りの課題を解決することもできます。
+      </p>
+      <p class="text-slate-600 dark:text-slate-300">
+        ウェブアプリケーションだけではなく、ウェブ制作の経験もあるので、ウェブ領域全般でバリューを発揮することができます。
+      </p>
+    </div>
+
+    <div class="glass-card p-6" use:scrollReveal={{ delay: 100 }}>
+      <h3 class="text-xl font-bold mb-3 text-slate-900 dark:text-white">関心のある技術</h3>
+      <ul class="list-disc ml-4 text-slate-600 dark:text-slate-300">
+        <li>Web Frontend (React)</li>
+        <li>Backend (Node.js, Go)</li>
+        <li>AWS・Google Cloud等のパブリッククラウド</li>
+        <li>IaC (Infrastructure as Code)</li>
+        <li>Cloudflare</li>
+        <li>Vim (Neovim)</li>
+      </ul>
+    </div>
+
+    <div class="glass-card p-6 lg:col-span-2" use:scrollReveal={{ delay: 200 }}>
+      <h3 class="text-xl font-bold mb-3 text-slate-900 dark:text-white">趣味</h3>
+      <p class="text-slate-600 dark:text-slate-300">ファッションが好きです。</p>
+      <p class="text-slate-600 dark:text-slate-300">渋谷や表参道に服を買いに行くことが多いです。</p>
+      <p class="text-slate-600 dark:text-slate-300">あとは、カフェに行ったりするのも好きです。</p>
+    </div>
   </div>
 </SectionRoot>

--- a/src/lib/components/sections/SectionRoot.svelte
+++ b/src/lib/components/sections/SectionRoot.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
+  import { scrollReveal } from '$lib/actions/scrollReveal';
   export let heading = '';
 </script>
 
-<section class="mt-8 mb-12">
+<section class="py-16 lg:py-24" use:scrollReveal>
   {#if heading !== ''}
     <h2
-      class="relative lg:mb-6 mb-4 text-3xl font-bold before:bg-blue-700 before:absolute before:-bottom-1 before:left-0 before:w-10 before:h-1"
+      class="relative lg:mb-10 mb-6 text-4xl lg:text-5xl font-extrabold tracking-tight text-slate-900 dark:text-white"
     >
       {heading}
+      <span
+        class="absolute -bottom-2 left-0 w-12 h-1.5 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400"
+      />
     </h2>
   {/if}
   <slot />

--- a/src/lib/components/sections/Skills.svelte
+++ b/src/lib/components/sections/Skills.svelte
@@ -1,21 +1,30 @@
 <script lang="ts">
   import SectionRoot from '$lib/components/sections/SectionRoot.svelte';
+  import { scrollReveal } from '$lib/actions/scrollReveal';
   import { All_SKILLS } from '$lib/data/allSkills';
 </script>
 
 <SectionRoot heading="Skills">
-  {#each All_SKILLS as item}
-    <div class="mb-4">
-      <h3 class="text-xl font-bold mb-2">{item.heading}</h3>
-      <ul class="flex gap-4 flex-wrap">
-        {#each item.skills as skill}
-          <li>
-            <span class="rounded-md px-4 py-2 text-sm font-medium bg-blue-100 text-blue-900">
-              {skill.title}
-            </span>
-          </li>
-        {/each}
-      </ul>
-    </div>
-  {/each}
+  <div class="grid gap-6 lg:grid-cols-2">
+    {#each All_SKILLS as item, i}
+      <div
+        class="glass-card p-6"
+        class:lg:col-span-2={i === All_SKILLS.length - 1 && All_SKILLS.length % 2 !== 0}
+        use:scrollReveal={{ delay: i * 100 }}
+      >
+        <h3 class="text-lg font-bold mb-4 text-slate-900 dark:text-white">{item.heading}</h3>
+        <ul class="flex gap-2.5 flex-wrap">
+          {#each item.skills as skill}
+            <li>
+              <span
+                class="inline-block rounded-lg px-3 py-1.5 text-sm font-medium bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 hover:border-cyan-400 dark:hover:border-cyan-400 transition-colors"
+              >
+                {skill.title}
+              </span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/each}
+  </div>
 </SectionRoot>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,12 +4,10 @@
   import '../app.css';
 </script>
 
-<div class="flex flex-col h-screen bg-red-200">
+<div class="flex flex-col min-h-screen">
   <Header />
-  <main class="flex-1 bg-amber-50 pt-20 dark:bg-gray-900 dark:text-white">
-    <div class="mx-auto w-10/12 lg:w-6/12">
-      <slot />
-    </div>
+  <main class="flex-1 bg-slate-50 dark:bg-slate-900 dark:text-slate-100 text-slate-800">
+    <slot />
   </main>
   <Footer />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,8 +14,10 @@
 </svelte:head>
 
 <Cat />
-<Profile />
-<Career />
-<Skills />
-<Others />
-<Contact />
+<div class="max-w-4xl mx-auto px-6">
+  <Profile />
+  <Career />
+  <Skills />
+  <Others />
+  <Contact />
+</div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,11 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
-  // add this section
-  purge: ['./src/**/*.html', './src/**/*.svelte'],
   content: ['./src/**/*.{html,js,svelte,ts}'],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'Noto Sans JP', 'system-ui', 'sans-serif'],
+        display: ['Inter', 'Noto Sans JP', 'sans-serif']
+      },
       keyframes: {
         'fade-in': {
           '0%': { opacity: '0' },
@@ -22,13 +24,23 @@ module.exports = {
         'zoom-out': {
           '0%': { opacity: '1', transform: 'translate(-50%, -50%) scale(1)' },
           '100%': { opacity: '0', transform: 'translate(-50%, -50%) scale(0.95)' }
+        },
+        float: {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-20px)' }
+        },
+        'slide-up': {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
         }
       },
       animation: {
         'fade-in': 'fade-in 200ms ease-out',
         'fade-out': 'fade-out 200ms ease-in',
         'zoom-in': 'zoom-in 300ms ease-out',
-        'zoom-out': 'zoom-out 300ms ease-in'
+        'zoom-out': 'zoom-out 300ms ease-in',
+        float: 'float 6s ease-in-out infinite',
+        'slide-up': 'slide-up 0.6s ease-out forwards'
       }
     }
   },


### PR DESCRIPTION
## Summary
- 猫アニメーションをフルビューポートのヒーローセクションに昇格（グラデーション背景 + 浮遊装飾オーブ + スクロールインジケーター）
- カラーシステムをamber/blue系からslate/cyan/violetグラデーション系に統一
- 全カード要素にglassmorphism（backdrop-blur + 半透明背景）を適用
- IntersectionObserverによるスクロールフェードインアニメーションを追加
- Inter + Noto Sans JPフォントを導入
- タイムラインを縦型カードレイアウトに、スキルをカードグリッドにリデザイン
- ソーシャルリンクをアイコンカードグリッドに変更

## Test plan
- [x] `pnpm dev`でローカル起動し全セクション表示確認
- [x] ライト/ダークモード両方で表示確認
- [x] モバイル幅(375px)とデスクトップ幅でレスポンシブ確認
- [x] Lottie猫アニメーションが正常再生されることを確認
- [x] スクロールアニメーションが各セクションで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)